### PR TITLE
Download to temporary file

### DIFF
--- a/flatcar-release-mirror.sh
+++ b/flatcar-release-mirror.sh
@@ -74,14 +74,16 @@ download_file() {
     echo -n "."
     echo "Downloading $url"  >> "$logfile"
   fi
+  rm -f "$file".tmp
   # No "-C -" because we might have changed contents
   # Use "-R" to keep the original time for the ETag
-  log=$(curl "$url" -R -o "$file" $CURLARGS 2>&1)
+  log=$(curl "$url" -R -o "$file".tmp $CURLARGS 2>&1)
   if [[ "$?" != "0" ]]; then
     echo
     echo "Failed to download $url" >> /dev/stderr
     return 1
   fi
+  mv -f "$file".tmp "$file"
   return 0
 }
 

--- a/flatcar-release-mirror.sh
+++ b/flatcar-release-mirror.sh
@@ -49,7 +49,7 @@ download_file() {
   # this mechanism should work fine.
   if [[ -n "$only_files" ]]; then
     if [[ -z "$(echo "$file" | grep "$only_files")" ]]; then
-      echo "Skipping $file as it does not match with list of files $only_files"
+      echo "Skipping $file as it does not match with list of files $only_files" >> "$logfile"
       return 0
     fi
   fi


### PR DESCRIPTION
Mirroring was overwriting the existing file which caused the file
    for a client to be damaged when the client starts the download at
    the same time.
    Use a temporary file and then an atomic move to overwrite the old file.